### PR TITLE
feat | Create update user

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Post, Body, Param, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Put,
+  Get,
+  Post,
+  Body,
+  Param,
+  UseGuards,
+} from '@nestjs/common';
 import { UsersService } from './users.service';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 
@@ -11,6 +19,15 @@ export class UsersController {
   @Post()
   create(@Body() body: { email: string; password: string }) {
     return this.usersService.createUser(body.email, body.password);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Put(':id')
+  updateUser(
+    @Param('id') id: number,
+    @Body() body: { email?: string; password?: string },
+  ) {
+    return this.usersService.updateUser(id, body);
   }
 
   // Protegendo a rota para listar todos os usuários


### PR DESCRIPTION
##Description
This pull request introduces the updateUser feature, allowing users to update their email and/or password in the system. The changes include:

Controller: Added a PUT /users/:id endpoint to handle user updates.
Service: Implemented updateUser logic with validation to ensure the user exists before applying changes. Passwords are securely hashed using bcrypt if updated.
Documentation: Added comments to explain the update functionality.
Error Handling: Added validation and appropriate error responses for missing or invalid user IDs.

##Testing
Verified with manual testing via Postman that:
A user can update their email and/or password.
Proper error handling occurs when the user ID is invalid or not found.

##Impact
Improves functionality for managing user details.
Enhances security by ensuring password updates are hashed before saving.